### PR TITLE
Setup the LLM module

### DIFF
--- a/examples/.env.sample
+++ b/examples/.env.sample
@@ -1,0 +1,5 @@
+# AWS Credentials for Bedrock access
+# Replace with your actual AWS credentials
+AWS_ACCESS_KEY_ID=your_access_key_here
+AWS_SECRET_ACCESS_KEY=your_secret_key_here
+AWS_DEFAULT_REGION=us-west-2

--- a/examples/bedrock_example.py
+++ b/examples/bedrock_example.py
@@ -1,0 +1,84 @@
+"""Example usage of the Bedrock provider."""
+
+import os
+import sys
+import logging
+from typing import Dict, Any
+from dotenv import load_dotenv
+
+# Add the parent directory to the path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from aki.llm import llm_factory
+from aki.llm.providers.bedrock import BedrockProvider
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Load environment variables from .env file if present
+load_dotenv()
+
+
+def configure_provider() -> None:
+    """Configure the Bedrock provider."""
+    # Register the Bedrock provider (if not already registered)
+    if "bedrock" not in [provider.name for provider in llm_factory._providers.values()]:
+        logger.info("Registering Bedrock provider")
+        llm_factory.register_provider("bedrock", BedrockProvider())
+
+    # List available models
+    models = llm_factory.list_models()
+    logger.info(f"Available models: {', '.join(models)}")
+
+
+def get_model_config() -> Dict[str, Any]:
+    """Get model configuration from environment or use defaults."""
+    return {
+        "model_id": os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-instant-v1"),
+        "temperature": float(os.environ.get("BEDROCK_TEMPERATURE", "0.7")),
+        "max_tokens": int(os.environ.get("BEDROCK_MAX_TOKENS", "512")),
+    }
+
+
+def ask_model(query: str) -> None:
+    """Ask a question to the model."""
+    # Configure provider if not already done
+    configure_provider()
+    
+    # Get model configuration
+    config = get_model_config()
+    model_id = f"(bedrock){config['model_id']}"
+    
+    logger.info(f"Using model: {model_id}")
+    logger.info(f"Temperature: {config['temperature']}")
+    logger.info(f"Max tokens: {config['max_tokens']}")
+    
+    # Create the model
+    try:
+        model = llm_factory.create_model(
+            "bedrock-test",
+            model_id,
+            temperature=config['temperature'],
+            max_tokens=config['max_tokens'],
+        )
+        
+        # Ask the question
+        logger.info(f"Asking: {query}")
+        response = model.invoke([{"type": "human", "content": query}])
+        
+        print("\nResponse:")
+        print("-" * 50)
+        print(response.content)
+        print("-" * 50)
+        
+    except Exception as e:
+        logger.error(f"Error invoking model: {e}")
+
+
+if __name__ == "__main__":
+    # Get the query from command line args or use a default
+    query = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else "Tell me a short joke about programming."
+    
+    # Ask the model
+    ask_model(query)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,12 @@ dependencies = [
 dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
-    "black>=23.7.0",
     "flake8>=6.1.0",
     "coverage>=7.8.0",
     "pytest-asyncio>=0.26.0",
     "hatch>=1.14.1",
     "pip>=25.0.1",
+    "ruff>=0.11.4",
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "langchain-aws>=0.2.18",
     "python-dotenv>=1.1.0",
     "tiktoken>=0.9.0",
+    "ollama>=0.4.7",
+    "langchain-ollama>=0.3.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ dependencies = [
     "langchain==0.3.18",
     "langgraph==0.3.16",
     "langchain_community==0.3.17",
-    "duckduckgo-search>=2025.4.4",
+    "duckduckgo-search<=8.0.0",
+    "langchain-aws>=0.2.18",
+    "python-dotenv>=1.1.0",
+    "tiktoken>=0.9.0",
 ]
 
 [project.optional-dependencies]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 pythonpath = src
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -19,7 +19,7 @@ echo -e "${YELLOW}Current directory: $(pwd)${NC}"
 
 # 1. Run linting with Black
 echo -e "\n${YELLOW}Step 1/4: Running code formatter (black)...${NC}"
-uv run black src tests
+uv run ruff check --fix src tests
 echo -e "${GREEN}✓ Formatting complete${NC}"
 
 # 2. Run pytest with coverage

--- a/src/aki/app.py
+++ b/src/aki/app.py
@@ -1,23 +1,108 @@
+"""Simple chat application with Chainlit."""
+
 import sys
+import socket
+import logging
 import chainlit as cl
 from chainlit.cli import chainlit_run
-from aki.version import __version__
+from .version import __version__
+
+# Configure basic logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+@cl.on_chat_start
+async def on_chat_start():
+    """Initialize the chat session when a new conversation starts."""
+    # Welcome message
+    await cl.Message(
+        content=f"Welcome to Aki v{__version__}! How can I help you today?"
+    ).send()
 
 
 @cl.on_message
 async def on_message(message: cl.Message):
-    # Your custom logic goes here...
+    """Process incoming user messages."""
+    try:
+        # Process the user's message here
+        # This is a simple echo response for demonstration
+        response = f"You said: {message.content}"
 
-    # Send a response back to the user
-    await cl.Message(
-        content=f"Received: {message.content}",
-    ).send()
+        # Send response back to the user
+        await cl.Message(content=response).send()
+    except Exception as e:
+        error_message = f"An error occurred: {str(e)}"
+        logger.error(error_message, exc_info=True)
+        await cl.Message(content=error_message).send()
+
+
+def is_port_in_use(port: int) -> bool:
+    """Check if a port is in use."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("localhost", port))
+            return False
+        except OSError:
+            return True
+
+
+def find_available_port(start_port: int) -> int:
+    """Find the next available port starting from start_port."""
+    port = start_port
+    while is_port_in_use(port):
+        port += 1
+        if port > 65535:  # Maximum port number
+            raise RuntimeError("No available ports found")
+    return port
+
+
+def print_welcome_message():
+    """Print a welcome message to the console."""
+    print(f"\n{'=' * 60}")
+    print(f"Welcome to Aki v{__version__}!")
+    print(f"{'=' * 60}\n")
 
 
 def main():
     """Entry point for the application."""
-    port = 8888
+    # Simple manual argument parsing
+    default_port = 8888
+    debug_mode = False
+
+    # Process command line arguments manually
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ["-v", "--version"]:
+            print(f"Aki {__version__}")
+            sys.exit(0)
+        elif arg == "--debug":
+            debug_mode = True
+        elif arg == "--port" and i + 1 < len(args):
+            try:
+                default_port = int(args[i + 1])
+                i += 1  # Skip next argument as we've used it
+            except ValueError:
+                print(f"Invalid port number: {args[i + 1]}")
+        i += 1
+
+    # Handle port configuration
+    port = find_available_port(default_port)
+    if port != default_port:
+        print(f"Port {default_port} is in use. Using port {port} instead.")
+
+    # Set up chainlit arguments
     sys.argv = [sys.argv[0], __file__, "--port", str(port)]
+    if debug_mode:
+        sys.argv.extend(["--debug"])
+
+    print_welcome_message()
+    print(f"Aki {__version__} is available at http://localhost:{port}")
     chainlit_run()
 
 

--- a/src/aki/config/__init__.py
+++ b/src/aki/config/__init__.py
@@ -1,0 +1,6 @@
+"""Configuration utilities for Aki."""
+
+from .paths import get_aki_home, get_env_file
+from .environment import get_config_value
+
+__all__ = ["get_aki_home", "get_env_file", "get_config_value"]

--- a/src/aki/config/environment.py
+++ b/src/aki/config/environment.py
@@ -1,0 +1,59 @@
+"""Environment configuration handling for Aki."""
+
+import os
+import logging
+from typing import Dict, Optional
+
+from .paths import get_env_file
+
+logger = logging.getLogger(__name__)
+
+
+def load_env_variables() -> Dict[str, str]:
+    """Load environment variables from ~/.aki/.env file.
+    
+    Returns:
+        Dictionary of environment variables loaded from the file
+    """
+    env_vars = {}
+    env_path = get_env_file()
+    
+    if env_path.exists():
+        try:
+            logger.debug(f"Loading environment from {env_path}")
+            with open(env_path) as f:
+                env_content = f.read()
+                env_vars = dict(
+                    line.split("=", 1)
+                    for line in env_content.splitlines()
+                    if "=" in line and not line.strip().startswith("#")
+                )
+        except Exception as e:
+            logger.warning(f"Error reading {env_path}: {e}")
+    else:
+        logger.debug(f"Environment file not found: {env_path}")
+        
+    return env_vars
+
+
+def get_config_value(key: str, default: Optional[str] = None) -> Optional[str]:
+    """Get a configuration value from system env or ~/.aki/.env file.
+    
+    First checks if the variable is set in the system environment,
+    then falls back to the .env file if available.
+    
+    Args:
+        key: The environment variable name
+        default: Default value if the variable is not found
+        
+    Returns:
+        The value of the environment variable, or the default value if not found
+    """
+    # First check system environment
+    value = os.environ.get(key)
+    if value is not None:
+        return value
+    
+    # Then check .env file
+    env_vars = load_env_variables()
+    return env_vars.get(key, default)

--- a/src/aki/config/paths.py
+++ b/src/aki/config/paths.py
@@ -1,0 +1,24 @@
+"""Path utilities for Aki configuration."""
+
+from pathlib import Path
+
+
+def get_aki_home() -> Path:
+    """Get the Aki home directory path.
+    
+    Returns:
+        Path to the ~/.aki directory, creating it if it doesn't exist
+    """
+    home = Path.home()
+    aki_dir = home / ".aki"
+    aki_dir.mkdir(exist_ok=True)
+    return aki_dir
+
+
+def get_env_file() -> Path:
+    """Get the path to the environment configuration file.
+    
+    Returns:
+        Path to the ~/.aki/.env file
+    """
+    return get_aki_home() / ".env"

--- a/src/aki/llm/__init__.py
+++ b/src/aki/llm/__init__.py
@@ -1,0 +1,10 @@
+"""LLM module for Aki."""
+
+from .factory import LLMFactory
+from .capabilities import ModelCapability
+from .providers import BedrockProvider
+
+# Create a default factory instance
+llm_factory = LLMFactory()
+
+__all__ = ["llm_factory", "ModelCapability", "LLMFactory", "BedrockProvider"]

--- a/src/aki/llm/capabilities.py
+++ b/src/aki/llm/capabilities.py
@@ -1,0 +1,23 @@
+from typing import Protocol, runtime_checkable
+from enum import Enum, auto
+
+
+class ModelCapability(Enum):
+    TEXT_TO_TEXT = auto()
+    TEXT_TO_IMAGE = auto()
+    IMAGE_TO_TEXT = auto()
+    IMAGE_TO_IMAGE = auto()
+    TOOL_CALLING = auto()
+    STRUCTURED_OUTPUT = auto()
+    AUDIO_TO_TEXT = auto()
+    TEXT_TO_AUDIO = auto()
+    AUDIO_TO_AUDIO = auto()
+    TEXT_EMBEDDING = auto()
+    EXTENDED_REASONING = auto()
+
+
+@runtime_checkable
+class CapableModel(Protocol):
+    def get_capabilities(self) -> set[ModelCapability]:
+        """Return set of capabilities this model supports"""
+        pass

--- a/src/aki/llm/factory.py
+++ b/src/aki/llm/factory.py
@@ -1,0 +1,73 @@
+from typing import Dict, Optional, List, Set
+import logging
+from langchain_core.language_models.chat_models import BaseChatModel
+from .providers.base import LLMProvider
+from .capabilities import ModelCapability
+
+
+class LLMFactory:
+    def __init__(self):
+        self._providers: Dict[str, LLMProvider] = {}
+
+    def register_provider(self, prefix: str, provider: LLMProvider):
+        self._providers[prefix] = provider
+
+    def create_model(
+        self, name: str, model: str, tools: Optional[List] = None, **kwargs
+    ) -> BaseChatModel:
+        for provider_name, provider in self._providers.items():
+            prefix = f"({provider_name})"
+            if model.startswith(prefix):
+                model_name = model.replace(prefix, "")
+                if ModelCapability.TOOL_CALLING in provider.capabilities.get(
+                    model_name, set()
+                ):
+                    return provider.create_model(name, model_name, tools, **kwargs)
+                else:
+                    if tools is not None and tools != []:
+                        logging.debug(
+                            f"Model {model_name} does not support tool calling"
+                        )
+                    return provider.create_model(name, model_name, **kwargs)
+        raise ValueError(f"No provider found for model: {model}")
+
+    def get_model_capabilities(self, model: str) -> Set[ModelCapability]:
+        """Get capabilities for a specific model."""
+        for provider_name, provider in self._providers.items():
+            prefix = f"({provider_name})"
+            if model.startswith(prefix):
+                model_name = model.replace(prefix, "")
+                return provider.capabilities.get(model_name, set())
+        return set()
+
+    def list_models(
+        self, capabilities: Optional[set[ModelCapability]] = None
+    ) -> List[str]:
+        models = []
+        for provider in self._providers.values():
+            try:
+                provider_models = provider.list_models()
+                if capabilities:
+                    models.extend(
+                        [
+                            f"({provider.name}){model_name}"
+                            for model_name in provider_models
+                            if all(
+                                cap in provider.capabilities.get(model_name, set())
+                                for cap in capabilities
+                            )
+                        ]
+                    )
+                else:
+                    models.extend(
+                        [
+                            f"({provider.name}){model_name}"
+                            for model_name in provider_models
+                        ]
+                    )
+            except Exception as e:
+                logging.warning(
+                    f"Failed to list models for provider {provider.name}: {e}"
+                )
+                continue
+        return models

--- a/src/aki/llm/providers/__init__.py
+++ b/src/aki/llm/providers/__init__.py
@@ -1,0 +1,6 @@
+"""LLM providers for Aki."""
+
+from .base import LLMProvider, LLMModel
+from .bedrock import BedrockProvider
+
+__all__ = ["LLMProvider", "LLMModel", "BedrockProvider"]

--- a/src/aki/llm/providers/base.py
+++ b/src/aki/llm/providers/base.py
@@ -1,0 +1,33 @@
+from abc import ABC
+from typing import Optional, Dict
+from langchain_core.language_models.chat_models import BaseChatModel
+from ..capabilities import ModelCapability
+
+
+class LLMModel(BaseChatModel):
+    """Base model with capabilities"""
+
+    def __init__(self, capabilities: set[ModelCapability]):
+        self._capabilities = capabilities
+        super().__init__()
+
+    def get_capabilities(self) -> set[ModelCapability]:
+        return self._capabilities
+
+
+class LLMProvider(ABC):
+    def create_model(self, name: str, model: str, **kwargs) -> LLMModel:
+        pass
+
+    def list_models(
+        self, capabilities: Optional[set[ModelCapability]] = None
+    ) -> Dict[str, set[ModelCapability]]:
+        pass
+
+    @property
+    def name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def capabilities(self) -> Dict[str, set[ModelCapability]]:
+        raise NotImplementedError

--- a/src/aki/llm/providers/bedrock.py
+++ b/src/aki/llm/providers/bedrock.py
@@ -1,0 +1,288 @@
+"""Amazon Bedrock provider for Aki."""
+
+import logging
+import boto3
+from typing import Dict, List, Optional, Set, Any, Tuple
+from botocore.client import BaseClient, Config
+
+from langchain_aws import ChatBedrockConverse
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from aki.config import get_env_file
+from aki.config import get_config_value
+from ..capabilities import ModelCapability
+from .base import LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+def validate_bedrock_access(session: boto3.Session) -> bool:
+    """Validate Bedrock access by attempting to list foundation models.
+
+    Args:
+        session: boto3.Session to validate
+
+    Returns:
+        bool: True if the session has valid Bedrock access, False otherwise
+    """
+    try:
+        # Get region from environment or use default
+        region = get_config_value("AWS_DEFAULT_REGION", "us-west-2")
+        client = session.client("bedrock", region_name=region)
+        response = client.list_foundation_models()
+        models = response["modelSummaries"]
+        # TODO: need to verify models that we use
+        logger.debug(
+            f"Successfully validated Bedrock access. Found {len(models)} foundation models."
+        )
+        return True
+    except Exception as e:
+        logger.debug(f"Bedrock access validation failed: {str(e)}")
+        return False
+
+
+def create_session_from_env(env_vars: dict) -> Tuple[Optional[boto3.Session], str]:
+    """Create a boto3 session from environment variables.
+
+    Args:
+        env_vars: Dictionary containing AWS credentials
+
+    Returns:
+        Tuple[Optional[boto3.Session], str]: The created session (or None) and a message
+    """
+    aws_access_key = env_vars.get("AWS_ACCESS_KEY_ID")
+    aws_secret_key = env_vars.get("AWS_SECRET_ACCESS_KEY")
+
+    if not aws_access_key or not aws_secret_key:
+        return None, "Missing required AWS credentials"
+
+    session = boto3.Session(
+        aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key
+    )
+
+    if validate_bedrock_access(session):
+        return session, "Successfully validated credentials"
+    return None, "Failed to validate Bedrock access"
+
+
+class BedrockProvider(LLMProvider):
+    """Provider for Amazon Bedrock models."""
+
+    def __init__(self):
+        self._model_capabilities = self.capabilities
+        self._logger = logging.getLogger(__name__)
+        self._client = None
+
+    def _create_client(self) -> BaseClient:
+        """Create a Bedrock client with credential discovery.
+
+        Attempts to create a client using credentials in the following order:
+        1. Credentials from ~/.aki/.env file
+        2. AWS profile 'aki' (if it exists)
+
+        Returns:
+            BaseClient: A configured boto3 bedrock-runtime client
+        """
+        try:
+            # Get region from environment with fallback to default
+            region = get_config_value("AWS_DEFAULT_REGION", "us-west-2")
+            logger.debug(f"Using AWS region: {region}")
+            
+            config_obj = Config(
+                read_timeout=20000,
+                connect_timeout=20000,
+                retries={"max_attempts": 5, "mode": "adaptive"},
+            )
+
+            # 1. Try loading credentials from ~/.aki/.env
+            logger.debug("Attempting to use credentials from ~/.aki/.env")
+            env_path = get_env_file()
+            if env_path.exists():
+                try:
+                    # Load credentials from env file
+                    env_vars = {
+                        "AWS_ACCESS_KEY_ID": get_config_value("AWS_ACCESS_KEY_ID"),
+                        "AWS_SECRET_ACCESS_KEY": get_config_value("AWS_SECRET_ACCESS_KEY")
+                    }
+                    
+                    if env_vars["AWS_ACCESS_KEY_ID"] and env_vars["AWS_SECRET_ACCESS_KEY"]:
+                        session = boto3.Session(
+                            aws_access_key_id=env_vars["AWS_ACCESS_KEY_ID"],
+                            aws_secret_access_key=env_vars["AWS_SECRET_ACCESS_KEY"]
+                        )
+                        
+                        if validate_bedrock_access(session):
+                            logger.debug("Successfully validated credentials from ~/.aki/.env")
+                            return session.client(
+                                "bedrock-runtime", region_name=region, config=config_obj
+                            )
+                        logger.debug("Failed to validate credentials from ~/.aki/.env")
+                except Exception as e:
+                    logger.warning(f"Error using credentials from ~/.aki/.env: {e}")
+            else:
+                logger.debug("No ~/.aki/.env file found")
+
+            # 2. Try profile-based authentication
+            logger.debug("Attempting to use aki profile authentication")
+            try:
+                session = boto3.Session(profile_name="aki")
+                if validate_bedrock_access(session):
+                    logger.debug("Successfully validated aki profile credentials")
+                    return session.client(
+                        "bedrock-runtime", region_name=region, config=config_obj
+                    )
+                logger.debug("Failed to validate aki profile credentials")
+            except Exception as e:
+                logger.debug(f"Error using aki profile: {e}")
+
+            # If we get here, neither method worked
+            raise ValueError(
+                "Failed to create Bedrock client. Could not find valid credentials in:\n"
+                "1. ~/.aki/.env file\n"
+                "2. AWS profile 'aki'\n"
+            )
+
+        except Exception as e:
+            self._logger.error(f"Failed to create Bedrock client: {e}")
+            raise
+
+    def _get_client(self) -> BaseClient:
+        """Get or create a Bedrock client."""
+        if not self._client:
+            self._client = self._create_client()
+        return self._client
+
+    def _get_model_config(
+        self, model: str, tools: Optional[List] = None, **kwargs
+    ) -> Dict[str, Any]:
+        """Get configuration for a specific model.
+
+        This is a protected method that can be overridden by subclasses
+        to implement custom model configuration logic.
+
+        Args:
+            model: The model ID
+            tools: Optional list of tools for tool-calling models
+            **kwargs: Additional model configuration parameters
+
+        Returns:
+            Dict[str, Any]: Model configuration dictionary
+        """
+        # Extract extended reasoning settings if present
+        enable_reasoning = kwargs.pop("enable_reasoning", False)
+        budget_tokens = kwargs.pop("budget_tokens", 1024)
+
+        # Base model configuration
+        model_kwargs = {
+            "model": model,
+            "max_tokens": kwargs.pop("max_tokens", 8192),
+            "temperature": kwargs.pop("temperature", 0.6),
+        }
+
+        # Add extended reasoning configuration if enabled for supported models
+        if (
+            enable_reasoning
+            and ModelCapability.EXTENDED_REASONING
+            in self._model_capabilities.get(model, set())
+        ):
+            self._logger.debug(
+                f"Enabling extended reasoning for {model} with budget {budget_tokens}"
+            )
+            # Claude 3.7 requires temperature=1.0 for extended reasoning
+            model_kwargs["temperature"] = 1.0
+            # Increase max_tokens to accommodate reasoning budget plus regular response
+            model_kwargs["max_tokens"] = budget_tokens + model_kwargs.get(
+                "max_tokens", 8192
+            )
+            # Add reasoning configuration to model_kwargs
+            model_kwargs["additional_model_request_fields"] = {
+                "thinking": {"type": "enabled", "budget_tokens": budget_tokens},
+                "anthropic_beta": ["token-efficient-tools-2025-02-19"],
+            }
+
+        # Add any remaining kwargs
+        for key, value in kwargs.items():
+            model_kwargs[key] = value
+
+        return model_kwargs
+
+    def create_model(
+        self, name: str, model: str, tools: Optional[List] = None, **kwargs
+    ) -> BaseChatModel:
+        """Create a new Bedrock chat model.
+
+        Args:
+            name: A name for the model instance
+            model: The Bedrock model ID
+            tools: Optional list of tools for tool-calling models
+            **kwargs: Additional arguments to pass to the model
+
+        Returns:
+            A configured ChatBedrockConverse instance
+        """
+        client = self._get_client()
+        model_kwargs = self._get_model_config(model, tools, **kwargs)
+        model_kwargs["client"] = client
+
+        try:
+            llm = ChatBedrockConverse(name=name, **model_kwargs)
+
+            # Add tools if provided and supported
+            if (
+                tools
+                and len(tools) > 0
+                and ModelCapability.TOOL_CALLING
+                in self._model_capabilities.get(model, set())
+            ):
+                llm = llm.bind_tools(tools)
+
+            return llm
+        except Exception as e:
+            self._logger.error(f"Failed to create Bedrock model {model}: {e}")
+            raise
+
+    def list_models(self) -> List[str]:
+        """List all available models from this provider.
+
+        Returns:
+            List of model IDs that can be used with this provider
+        """
+        return list(self._model_capabilities.keys())
+
+    @property
+    def name(self) -> str:
+        """Get the name of this provider."""
+        return "bedrock"
+
+    @property
+    def capabilities(self) -> Dict[str, Set[ModelCapability]]:
+        return {
+            "us.anthropic.claude-3-7-sonnet-20250219-v1:0": {
+                ModelCapability.TEXT_TO_TEXT,
+                ModelCapability.IMAGE_TO_TEXT,
+                ModelCapability.TOOL_CALLING,
+                ModelCapability.STRUCTURED_OUTPUT,
+                ModelCapability.EXTENDED_REASONING,
+            },
+            "us.anthropic.claude-3-5-sonnet-20241022-v2:0": {
+                ModelCapability.TEXT_TO_TEXT,
+                ModelCapability.IMAGE_TO_TEXT,
+                ModelCapability.TOOL_CALLING,
+                ModelCapability.STRUCTURED_OUTPUT,
+            },
+            "us.anthropic.claude-3-5-haiku-20241022-v1:0": {
+                ModelCapability.TEXT_TO_TEXT,
+                ModelCapability.IMAGE_TO_TEXT,
+                ModelCapability.TOOL_CALLING,
+                ModelCapability.STRUCTURED_OUTPUT,
+            },
+            "us.anthropic.claude-3-5-sonnet-20240620-v1:0": {
+                ModelCapability.TEXT_TO_TEXT,
+                ModelCapability.IMAGE_TO_TEXT,
+                ModelCapability.TOOL_CALLING,
+                ModelCapability.STRUCTURED_OUTPUT,
+            },
+            "stability.stable-image-ultra-v1:0": {ModelCapability.TEXT_TO_IMAGE},
+            "stability.stable-image-core-v1:0": {ModelCapability.TEXT_TO_IMAGE},
+            "us.deepseek.r1-v1:0": {ModelCapability.TEXT_TO_TEXT},
+        }

--- a/src/aki/llm/providers/ollama.py
+++ b/src/aki/llm/providers/ollama.py
@@ -1,0 +1,76 @@
+from typing import Optional, List, Dict, Set
+import logging
+import requests
+from requests.exceptions import ConnectionError, RequestException
+import ollama
+from langchain_core.language_models import BaseChatModel
+from langchain_ollama.chat_models import ChatOllama
+
+from aki.llm import ModelCapability
+from aki.llm.providers import LLMProvider
+
+
+class OllamaProvider(LLMProvider):
+    OLLAMA_API = "http://localhost:11434"
+
+    def is_available(self) -> bool:
+        """Check if Ollama service is available"""
+        try:
+            requests.get(f"{self.OLLAMA_API}/api/version", timeout=1)
+            return True
+        except (ConnectionError, RequestException):
+            logging.debug("Ollama service is not available")
+            return False
+
+    def create_model(
+        self, name: str, model: str, tools: Optional[List] = None, **kwargs
+    ) -> BaseChatModel:
+        if not self.is_available():
+            raise RuntimeError("Ollama service is not available")
+
+        llm = ChatOllama(
+            name=name,
+            model=model,
+            base_url=self.OLLAMA_API,
+            temperature=0.2,
+        )
+
+        if (
+            tools
+            and len(tools) > 0
+            and ModelCapability.TOOL_CALLING in self.capabilities.get(model, set())
+        ):
+            llm = llm.bind_tools(tools)
+        return llm
+
+    def list_models(self) -> List[str]:
+        if not self.is_available():
+            logging.debug("Ollama service is not available, returning empty model list")
+            return []
+
+        try:
+            return [m.model for m in ollama.list().models]
+        except Exception as e:
+            logging.warning(f"Failed to list Ollama models: {e}")
+            return []
+
+    @property
+    def name(self) -> str:
+        return "ollama"
+
+    @property
+    def capabilities(self) -> Dict[str, Set[ModelCapability]]:
+        if not self.is_available():
+            return {}
+
+        return {
+            "deepseek-r1:70b": {
+                ModelCapability.TEXT_TO_TEXT,
+                ModelCapability.STRUCTURED_OUTPUT,
+            },
+            "MFDoom/deepseek-r1-tool-calling:70b": {
+                ModelCapability.TEXT_TO_TEXT,
+                ModelCapability.TOOL_CALLING,
+                ModelCapability.STRUCTURED_OUTPUT,
+            },
+        }

--- a/src/aki/llm/token_counter.py
+++ b/src/aki/llm/token_counter.py
@@ -1,0 +1,55 @@
+from typing import List, Any
+import json
+
+import tiktoken
+from langchain_core.messages import (
+    BaseMessage,
+    ToolMessage,
+    HumanMessage,
+    AIMessage,
+    SystemMessage,
+)
+
+
+def str_token_counter(text: str) -> int:
+    enc = tiktoken.get_encoding("o200k_base")
+    return len(enc.encode(text))
+
+
+def tiktoken_counter(messages: List[BaseMessage]) -> int:
+    """Approximately reproduce https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
+
+    For simplicity only supports str Message.contents.
+    """
+    num_tokens = 3  # every reply is primed with <|start|>assistant<|message|>
+    tokens_per_message = 3
+    tokens_per_name = 1
+    for msg in messages:
+        if isinstance(msg, HumanMessage):
+            role = "user"
+        elif isinstance(msg, AIMessage):
+            role = "assistant"
+        elif isinstance(msg, ToolMessage):
+            role = "tool"
+        elif isinstance(msg, SystemMessage):
+            role = "system"
+        else:
+            raise ValueError(f"Unsupported messages type {msg.__class__}")
+        num_tokens += (
+            tokens_per_message
+            + str_token_counter(role)
+            + str_token_counter(format_content(msg.content))
+        )
+        if msg.name:
+            num_tokens += tokens_per_name + str_token_counter(msg.name)
+    return num_tokens
+
+
+def format_content(content: Any) -> str:
+    """Convert content to string if it's not already a string."""
+    if isinstance(content, str):
+        return content
+    elif isinstance(content, (dict, list)):
+        return json.dumps(content)
+    else:
+        return str(content)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-# Test package initialization
+"""Tests for the Aki package."""

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for the Aki package."""

--- a/tests/integration/test_bedrock_provider.py
+++ b/tests/integration/test_bedrock_provider.py
@@ -1,0 +1,81 @@
+"""Integration tests for Bedrock provider."""
+
+import os
+import pytest
+from typing import Generator
+import logging
+
+from aki.llm import ModelCapability
+from aki.llm.providers.bedrock import BedrockProvider
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Skip these tests if credentials are not available
+pytestmark = pytest.mark.skipif(
+    os.environ.get("AWS_ACCESS_KEY_ID") is None or os.environ.get("AWS_SECRET_ACCESS_KEY") is None,
+    reason="AWS credentials not available"
+)
+
+
+@pytest.fixture
+def bedrock_provider() -> Generator[BedrockProvider, None, None]:
+    """Fixture to create and register a Bedrock provider."""
+    provider = BedrockProvider()
+    yield provider
+
+
+@pytest.fixture
+def model_id() -> str:
+    """Get a model ID to use for testing."""
+    # Use a default model that's relatively inexpensive
+    return os.environ.get("BEDROCK_TEST_MODEL_ID", "us.anthropic.claude-3-5-sonnet-20241022-v2:0")
+
+
+class TestBedrockProvider:
+    """Tests for the Bedrock provider."""
+
+    def test_provider_initialization(self, bedrock_provider):
+        """Test that the provider initializes correctly."""
+        assert bedrock_provider.name == "bedrock"
+        assert len(bedrock_provider.capabilities) > 0
+
+    def test_list_models(self, bedrock_provider):
+        """Test listing available models."""
+        models = bedrock_provider.list_models()
+        assert len(models) > 0
+        # Check that at least one model from each supported provider exists
+        assert any("claude" in model.lower() for model in models)
+        assert any("stable-image" in model.lower() for model in models)
+
+    def test_model_capabilities(self, bedrock_provider, model_id):
+        """Test getting model capabilities."""
+        # Update to use a model we know exists in our capabilities dict
+        test_model_id = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        capabilities = bedrock_provider.capabilities.get(test_model_id)
+        assert capabilities is not None
+        assert ModelCapability.TEXT_TO_TEXT in capabilities
+
+
+@pytest.mark.slow
+class TestBedrockModelIntegration:
+    """Integration tests for Bedrock models that make actual API calls."""
+
+    def test_create_model(self, bedrock_provider, model_id):
+        """Test creating a model instance."""
+        model = bedrock_provider.create_model("test", model_id)
+        assert model is not None
+        # LangChain models don't have get_capabilities, check the provider capabilities instead
+        assert ModelCapability.TEXT_TO_TEXT in bedrock_provider.capabilities.get(model_id, set())
+
+    def test_model_generation(self, bedrock_provider, model_id):
+        """Test generating text from the model."""
+        try:
+            model = bedrock_provider.create_model("test", model_id)
+            result = model.invoke([{"type": "human", "content": "Say 'Hello, Aki!' and nothing else."}])
+            assert result is not None
+            assert "hello, aki!" in result.content.lower()
+        except Exception as e:
+            logger.error(f"Failed to generate text with model {model_id}: {e}")
+            pytest.skip(f"Bedrock API error: {e}")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -47,7 +47,7 @@ class TestAsyncFunctions:
 
         # Verify Message was created with correct content
         mock_message.assert_called_once()
-        mock_message.assert_called_with(content="Received: Test message")
+        mock_message.assert_called_with(content="You said: Test message")
 
         # Verify send was called
         mock_instance.send.assert_called_once()

--- a/tests/test_bedrock_provider.py
+++ b/tests/test_bedrock_provider.py
@@ -1,0 +1,254 @@
+"""Tests for the Bedrock provider."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+from aki.llm.capabilities import ModelCapability
+from aki.llm.providers.bedrock import BedrockProvider, validate_bedrock_access, create_session_from_env
+
+
+class TestBedrockHelperFunctions:
+    """Tests for Bedrock helper functions."""
+    
+    @patch("boto3.Session")
+    @patch("aki.config.environment.get_config_value")
+    def test_validate_bedrock_access_success(self, mock_get_config, mock_session):
+        """Test validation with successful response."""
+        # Set up mocks
+        mock_get_config.return_value = "us-west-2"
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {"modelSummaries": ["model1", "model2"]}
+        mock_session_instance = MagicMock()
+        mock_session_instance.client.return_value = mock_client
+        mock_session.return_value = mock_session_instance
+        
+        # Call the function
+        result = validate_bedrock_access(mock_session_instance)
+        
+        # Check the result
+        assert result is True
+        mock_client.list_foundation_models.assert_called_once()
+    
+    @patch("boto3.Session")
+    @patch("aki.config.environment.get_config_value")
+    def test_validate_bedrock_access_failure(self, mock_get_config, mock_session):
+        """Test validation with an exception."""
+        # Set up mocks
+        mock_get_config.return_value = "us-west-2"
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.side_effect = Exception("Test error")
+        mock_session_instance = MagicMock()
+        mock_session_instance.client.return_value = mock_client
+        mock_session.return_value = mock_session_instance
+        
+        # Call the function
+        result = validate_bedrock_access(mock_session_instance)
+        
+        # Check the result
+        assert result is False
+    
+    def test_create_session_from_env_success(self):
+        """Test creating session with valid credentials."""
+        # Set up the env vars
+        env_vars = {"AWS_ACCESS_KEY_ID": "test_key", "AWS_SECRET_ACCESS_KEY": "test_secret"}
+        
+        # Mock boto3.Session and validate_bedrock_access
+        with patch("boto3.Session") as mock_session, \
+             patch("aki.llm.providers.bedrock.validate_bedrock_access", return_value=True):
+            
+            mock_session_instance = MagicMock()
+            mock_session.return_value = mock_session_instance
+            
+            # Call the function
+            session, message = create_session_from_env(env_vars)
+            
+            # Check the results
+            assert session == mock_session_instance
+            assert message == "Successfully validated credentials"
+            mock_session.assert_called_once_with(
+                aws_access_key_id="test_key", 
+                aws_secret_access_key="test_secret"
+            )
+    
+    def test_create_session_from_env_missing_keys(self):
+        """Test creating session with missing credentials."""
+        # Set up env vars with missing key
+        env_vars = {"AWS_ACCESS_KEY_ID": "test_key"}
+        
+        # Call the function
+        session, message = create_session_from_env(env_vars)
+        
+        # Check the results
+        assert session is None
+        assert message == "Missing required AWS credentials"
+    
+    def test_create_session_from_env_validation_failure(self):
+        """Test creating session with invalid credentials."""
+        # Set up the env vars
+        env_vars = {"AWS_ACCESS_KEY_ID": "test_key", "AWS_SECRET_ACCESS_KEY": "test_secret"}
+        
+        # Mock boto3.Session and validate_bedrock_access
+        with patch("boto3.Session") as mock_session, \
+             patch("aki.llm.providers.bedrock.validate_bedrock_access", return_value=False):
+            
+            mock_session_instance = MagicMock()
+            mock_session.return_value = mock_session_instance
+            
+            # Call the function
+            session, message = create_session_from_env(env_vars)
+            
+            # Check the results
+            assert session is None
+            assert message == "Failed to validate Bedrock access"
+
+
+class TestBedrockProvider:
+    """Tests for the BedrockProvider class."""
+    
+    def test_provider_initialization(self):
+        """Test that provider initialization creates capabilities."""
+        provider = BedrockProvider()
+        assert provider._model_capabilities is not None
+        assert provider._client is None
+    
+    def test_provider_name(self):
+        """Test the name property."""
+        provider = BedrockProvider()
+        assert provider.name == "bedrock"
+    
+    def test_capabilities(self):
+        """Test the capabilities property."""
+        provider = BedrockProvider()
+        capabilities = provider.capabilities
+        assert isinstance(capabilities, dict)
+        assert len(capabilities) > 0
+        # Check that at least one model has TEXT_TO_TEXT capability
+        assert any(ModelCapability.TEXT_TO_TEXT in caps for caps in capabilities.values())
+    
+    def test_create_client_from_env_file(self):
+        """Test creating client from env file."""
+        # Create a more isolated test with complete patching of the environment
+        with patch("aki.config.environment.get_config_value") as mock_get_config, \
+             patch("pathlib.Path.exists", return_value=True), \
+             patch("aki.llm.providers.bedrock.validate_bedrock_access", return_value=True), \
+             patch("boto3.Session") as mock_session_class:
+             
+            # Set up config mock
+            def config_value_side_effect(key, default=None):
+                if key == "AWS_DEFAULT_REGION":
+                    return "us-west-2"
+                elif key == "AWS_ACCESS_KEY_ID":
+                    return "test_key"
+                elif key == "AWS_SECRET_ACCESS_KEY":
+                    return "test_secret"
+                return default
+                
+            mock_get_config.side_effect = config_value_side_effect
+            
+            # Set up boto3 session mock
+            mock_session = MagicMock()
+            mock_client = MagicMock()
+            mock_session.client.return_value = mock_client
+            mock_session_class.return_value = mock_session
+            
+            # Create provider and call method
+            provider = BedrockProvider()
+            result = provider._create_client()
+            
+            # Check the result
+            assert result == mock_client
+            # Verify client was created with correct parameters
+            mock_session.client.assert_called_once()
+            assert mock_session.client.call_args[0][0] == "bedrock-runtime"
+            assert mock_session.client.call_args[1]["region_name"] == "us-west-2"
+    
+    @patch("aki.config.environment.get_config_value")
+    @patch("aki.config.paths.get_env_file")
+    @patch("pathlib.Path.exists")
+    @patch("boto3.Session")
+    @patch("aki.llm.providers.bedrock.validate_bedrock_access")
+    def test_create_client_from_profile(self, mock_validate, mock_session, 
+                                      mock_exists, mock_get_env_file, mock_get_config):
+        """Test creating client from aki profile."""
+        # Set up mocks
+        mock_get_config.return_value = "us-west-2"
+        mock_env_path = MagicMock()
+        mock_get_env_file.return_value = mock_env_path
+        mock_exists.return_value = False  # No .env file
+        mock_session_instance = MagicMock()
+        mock_client = MagicMock()
+        mock_session_instance.client.return_value = mock_client
+        mock_session.return_value = mock_session_instance
+        mock_validate.return_value = True
+        
+        # Create provider and call method
+        provider = BedrockProvider()
+        result = provider._create_client()
+        
+        # Check the result
+        assert result == mock_client
+        mock_session.assert_called_with(profile_name="aki")
+        mock_validate.assert_called_with(mock_session_instance)
+    
+    @patch("aki.config.environment.get_config_value")
+    @patch("aki.config.paths.get_env_file")
+    @patch("pathlib.Path.exists")
+    @patch("boto3.Session")
+    @patch("aki.llm.providers.bedrock.validate_bedrock_access")
+    def test_create_client_failure(self, mock_validate, mock_session, 
+                                mock_exists, mock_get_env_file, mock_get_config):
+        """Test failure to create a client."""
+        # Set up mocks
+        mock_get_config.return_value = "us-west-2"
+        mock_env_path = MagicMock()
+        mock_get_env_file.return_value = mock_env_path
+        mock_exists.return_value = False  # No .env file
+        mock_session_instance = MagicMock()
+        mock_session.return_value = mock_session_instance
+        mock_validate.return_value = False  # Validation fails
+        
+        # Create provider
+        provider = BedrockProvider()
+        
+        # Check that an error is raised
+        with pytest.raises(ValueError):
+            provider._create_client()
+    
+    def test_get_client_creates_once(self):
+        """Test that _get_client only creates a client once."""
+        with patch.object(BedrockProvider, '_create_client') as mock_create:
+            mock_client = MagicMock()
+            mock_create.return_value = mock_client
+            
+            provider = BedrockProvider()
+            # First call should create the client
+            client1 = provider._get_client()
+            # Second call should reuse the same client
+            client2 = provider._get_client()
+            
+            assert client1 == client2 == mock_client
+            mock_create.assert_called_once()
+    
+    def test_initialize_model_capabilities(self):
+        """Test model capabilities dictionary."""
+        provider = BedrockProvider()
+        capabilities = provider.capabilities
+        
+        # Check the result
+        assert isinstance(capabilities, dict)
+        assert len(capabilities) > 0
+        
+        # Check some specific model capabilities
+        # Use a model we know should exist
+        claude_37 = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+        assert claude_37 in capabilities
+        assert ModelCapability.TEXT_TO_TEXT in capabilities[claude_37]
+        assert ModelCapability.TOOL_CALLING in capabilities[claude_37]
+        assert ModelCapability.EXTENDED_REASONING in capabilities[claude_37]
+        
+        # Check another model capability
+        stable_image = "stability.stable-image-ultra-v1:0"
+        assert stable_image in capabilities
+        assert ModelCapability.TEXT_TO_IMAGE in capabilities[stable_image]
+        assert ModelCapability.EXTENDED_REASONING in capabilities[claude_37]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,134 @@
+"""Tests for the aki.config module."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch, mock_open
+
+from aki.config import paths
+from aki.config import environment
+
+
+class TestPaths:
+    """Tests for the paths module."""
+
+    @patch("pathlib.Path.mkdir")
+    @patch("pathlib.Path.home")
+    def test_get_aki_home(self, mock_home, mock_mkdir):
+        """Test that get_aki_home returns the correct path and creates directory."""
+        # Set up mock
+        mock_home_path = Path("/mock/home")
+        mock_home.return_value = mock_home_path
+        
+        # Call the function
+        result = paths.get_aki_home()
+        
+        # Check the result is correct
+        assert result == mock_home_path / ".aki"
+        
+        # Check that mkdir was called with exist_ok=True
+        mock_mkdir.assert_called_once_with(exist_ok=True)
+        
+    @patch("aki.config.paths.get_aki_home")
+    def test_get_env_file(self, mock_get_aki_home):
+        """Test that get_env_file returns the correct path."""
+        # Set up mock
+        mock_aki_home = Path("/mock/home/.aki")
+        mock_get_aki_home.return_value = mock_aki_home
+        
+        # Call the function
+        result = paths.get_env_file()
+        
+        # Check the result
+        assert result == mock_aki_home / ".env"
+
+
+class TestEnvironment:
+    """Tests for the environment module."""
+
+    @patch("aki.config.paths.get_env_file")
+    def test_load_env_variables_file_exists(self, mock_get_env_file):
+        """Test loading variables from an existing .env file."""
+        # Create a temporary file
+        env_content = "AWS_ACCESS_KEY_ID=test_key\nAWS_SECRET_ACCESS_KEY=test_secret\n# Comment\n"
+        
+        # Set up mocks
+        mock_path = Path("/mock/.aki/.env")
+        mock_get_env_file.return_value = mock_path
+        
+        # Mock the file exists check and open
+        with patch("pathlib.Path.exists", return_value=True), \
+             patch("builtins.open", mock_open(read_data=env_content)):
+            
+            # Call the function
+            result = environment.load_env_variables()
+            
+            # Check the result
+            assert result == {
+                "AWS_ACCESS_KEY_ID": "test_key",
+                "AWS_SECRET_ACCESS_KEY": "test_secret"
+            }
+            
+    @patch("aki.config.paths.get_env_file")
+    def test_load_env_variables_file_not_exists(self, mock_get_env_file):
+        """Test loading variables when .env file doesn't exist."""
+        # Set up mocks
+        mock_path = Path("/mock/.aki/.env")
+        mock_get_env_file.return_value = mock_path
+        
+        # Mock the file exists check
+        with patch("pathlib.Path.exists", return_value=False):
+            # Call the function
+            result = environment.load_env_variables()
+            
+            # Check the result is an empty dict
+            assert result == {}
+            
+    @patch("aki.config.environment.load_env_variables")
+    def test_get_config_value_from_env(self, mock_load_env):
+        """Test getting a value that exists in the environment."""
+        # Set a test environment variable
+        os.environ["TEST_VAR"] = "test_value"
+        
+        # Call the function
+        result = environment.get_config_value("TEST_VAR", "default")
+        
+        # Check the result
+        assert result == "test_value"
+        
+        # Environment should be checked first, so load_env_variables should not be called
+        mock_load_env.assert_not_called()
+        
+        # Clean up
+        del os.environ["TEST_VAR"]
+        
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("aki.config.environment.load_env_variables")
+    def test_get_config_value_from_file(self, mock_load_env):
+        """Test getting a value from the .env file."""
+        # Mock the return value of load_env_variables
+        mock_load_env.return_value = {"TEST_VAR": "file_value"}
+        
+        # Call the function
+        result = environment.get_config_value("TEST_VAR", "default")
+        
+        # Check the result
+        assert result == "file_value"
+        
+        # load_env_variables should be called
+        mock_load_env.assert_called_once()
+        
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("aki.config.environment.load_env_variables")
+    def test_get_config_value_default(self, mock_load_env):
+        """Test getting a value that doesn't exist."""
+        # Mock the return value of load_env_variables
+        mock_load_env.return_value = {}
+        
+        # Call the function
+        result = environment.get_config_value("TEST_VAR", "default")
+        
+        # Check the result is the default
+        assert result == "default"
+        
+        # load_env_variables should be called
+        mock_load_env.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -93,8 +92,11 @@ dependencies = [
     { name = "chainlit" },
     { name = "duckduckgo-search" },
     { name = "langchain" },
+    { name = "langchain-aws" },
     { name = "langchain-community" },
     { name = "langgraph" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
 ]
 
 [package.optional-dependencies]
@@ -107,6 +109,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -114,18 +117,21 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.7.0" },
     { name = "chainlit", git = "https://github.com/Aki-community/chainlit.git?subdirectory=backend&rev=main" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.8.0" },
-    { name = "duckduckgo-search", specifier = ">=2025.4.4" },
+    { name = "duckduckgo-search", specifier = "<=8.0.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.1.0" },
     { name = "hatch", marker = "extra == 'dev'", specifier = ">=1.14.1" },
     { name = "langchain", specifier = "==0.3.18" },
+    { name = "langchain-aws", specifier = ">=0.2.18" },
     { name = "langchain-community", specifier = "==0.3.17" },
     { name = "langgraph", specifier = "==0.3.16" },
     { name = "pip", marker = "extra == 'dev'", specifier = ">=25.0.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.4" },
+    { name = "tiktoken", specifier = ">=0.9.0" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "annotated-types"
@@ -202,6 +208,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926 },
     { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613 },
     { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646 },
+]
+
+[[package]]
+name = "boto3"
+version = "1.37.30"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/4b/fc19e5b08f5871ebc92a5bb8919133245bf63ab4e985b91e00ff78cd0905/boto3-1.37.30.tar.gz", hash = "sha256:beea13db5a5f5eaacecfa905cd1e4e933c13802f776198264eef229d6dffcc42", size = 111380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/3a/072a196ee038e859a6bdd52e374533c722e8b943c9a52c673dab70976d98/boto3-1.37.30-py3-none-any.whl", hash = "sha256:c75d78013eb43b354662cbd5f30bf537ab06641d3ed37aaad6fcf55a529d2991", size = 139560 },
+]
+
+[[package]]
+name = "botocore"
+version = "1.37.30"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/e7/29af47eb173faaeef3daabcc3e94bd8b6c1d87e1ba8eef1c6a18827b9cee/botocore-1.37.30.tar.gz", hash = "sha256:2f43b61e0231abbb4fbe8917acb1af98cb83dbab8c264c0d1f5ca0f16fdbf219", size = 13810655 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/85/cef0fdbd17f09cddc97c6b3182b099e2583ca77caec76f8a09f76794266e/botocore-1.37.30-py3-none-any.whl", hash = "sha256:d8ca899962d2079acd52483581f607322513910337a69bdae697766404b85b7d", size = 13476760 },
 ]
 
 [[package]]
@@ -445,22 +479,16 @@ wheels = [
 
 [[package]]
 name = "duckduckgo-search"
-version = "2025.4.4"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "lxml" },
     { name = "primp" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/25/aa/594674d0cfe45bdeb825b6383de2104c7320f3fb582eb97fb153dbdc8c71/duckduckgo_search-8.0.0.tar.gz", hash = "sha256:2a8e22092156e11d3c9195e1ce100fa0bce181d23d6f84b89228190498887736", size = 22253 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/15/bea5add03f5028dba529ddd9090ec6bd545e90926bdaa5a80b122e265110/duckduckgo_search-2025.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:18f21c972613f96fba344e2186757e862b724d9e574c956193ebc4f7fdfdf0fa", size = 78319 },
-    { url = "https://files.pythonhosted.org/packages/4a/ee/6ce5a5db585af44e4a811d0fd61431fe13789e51ade1102e78dd4f610a55/duckduckgo_search-2025.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c6944fb74b77aaab5759c8806c23ed20aa96624d1c49a2caf2b9f3b50c07057", size = 75032 },
-    { url = "https://files.pythonhosted.org/packages/e2/2f/a899d28de2d46541b24d33b969fedda74f6b00a4317e16cf207cbb896292/duckduckgo_search-2025.4.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e52028aeaa6151514a3115cc6fe616883cf9614fba2966792a415b7d97935b6", size = 95875 },
-    { url = "https://files.pythonhosted.org/packages/58/f3/cf71d8a286325f8a2d969bc0bda9e4defb01f1df2142887c965fa03adebb/duckduckgo_search-2025.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:f8a826f0d19eccba76d83d5034be8ae2e89f38263befd290c6ca613c8eed7ea2", size = 60488 },
-    { url = "https://files.pythonhosted.org/packages/85/d6/8d8775727dc18a38b5bbd5982383ff4d2a1b392afba4a998cac54e5c78f8/duckduckgo_search-2025.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a34c01f397f843ea9e4d00520eadfee087f837c3be9d7c2817c6006ec634c057", size = 78209 },
-    { url = "https://files.pythonhosted.org/packages/97/72/e1d4db7ef67fe35fe996ad492b253cdfba79652d5ef03c1e0159b6d1a05e/duckduckgo_search-2025.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7fc5625842c14b0f80b955f448757976295f4242ade632b6982b5ae002fe3d81", size = 74936 },
-    { url = "https://files.pythonhosted.org/packages/0b/7c/dc478eea16f30270183a2d5a964352404c00b3fcc5df8ce64a1220a5a556/duckduckgo_search-2025.4.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5434abee02b3d0c9759210a7d358aaa51214c1529ab1e6ddf374d94afa2a0e5e", size = 95537 },
-    { url = "https://files.pythonhosted.org/packages/75/eb/a16b1e6516c0156c04499367eb7b7bcaec1b69e91a25d449df2ee97f1377/duckduckgo_search-2025.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:a2cf0c92deb868eeb0694d864aa922e054e3a87da81009757af6af56d700f681", size = 60237 },
+    { url = "https://files.pythonhosted.org/packages/db/39/8e01afdea1bf7e67eb191217ad958a5c691f7739c9dacd00e8d77a663e4d/duckduckgo_search-8.0.0-py3-none-any.whl", hash = "sha256:0026f2c6961d457b4c526cb840dbb28a7b24f67ce38589618a5021fdb3f0e8bc", size = 18687 },
 ]
 
 [[package]]
@@ -794,6 +822,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256 },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -850,6 +887,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/23/612d99c74889f672fe349f43a458a42e449650ebd57073b9e96e0b6b2253/langchain-0.3.18.tar.gz", hash = "sha256:311ac227a995545ff7c3f74c7767930c5349edef0b39f19d3105b86d39316b69", size = 10223807 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/83/a4b41a1cf8b22fd708104d50edf98b720aa28647d3083d83b8348927a786/langchain-0.3.18-py3-none-any.whl", hash = "sha256:1a6e629f02a25962aa5b16932e8f073248104a66804ed5af1f78618ad7c1d38d", size = 1010321 },
+]
+
+[[package]]
+name = "langchain-aws"
+version = "0.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "langchain-core" },
+    { name = "numpy" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/dc/ea5cd31fadfeb2216578c0c7889490ab7c73e8eba02e13df8ea54192ed5a/langchain_aws-0.2.18.tar.gz", hash = "sha256:5aa98c90eda244419a27a433739ff4cb22ade749efff3dc8f120d76d420102fb", size = 96441 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/cf/3b97c6959de16cd474c550abf471822cf6a50eac7cd04d29bcd6041ffbd6/langchain_aws-0.2.18-py3-none-any.whl", hash = "sha256:9407322a0a94cce79e009bdadb64a83219ced87f6149bdc3bbba844768f2f223", size = 118349 },
 ]
 
 [[package]]
@@ -1717,6 +1769,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1795,6 +1859,44 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2024.11.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5f/bd69653fbfb76cf8604468d3b4ec4c403197144c7bfe0e6a5fc9e02a07cb/regex-2024.11.6.tar.gz", hash = "sha256:7ab159b063c52a0333c884e4679f8d7a85112ee3078fe3d9004b2dd875585519", size = 399494 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/30/9a87ce8336b172cc232a0db89a3af97929d06c11ceaa19d97d84fa90a8f8/regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:52fb28f528778f184f870b7cf8f225f5eef0a8f6e3778529bdd40c7b3920796a", size = 483781 },
+    { url = "https://files.pythonhosted.org/packages/01/e8/00008ad4ff4be8b1844786ba6636035f7ef926db5686e4c0f98093612add/regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdd6028445d2460f33136c55eeb1f601ab06d74cb3347132e1c24250187500d9", size = 288455 },
+    { url = "https://files.pythonhosted.org/packages/60/85/cebcc0aff603ea0a201667b203f13ba75d9fc8668fab917ac5b2de3967bc/regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:805e6b60c54bf766b251e94526ebad60b7de0c70f70a4e6210ee2891acb70bf2", size = 284759 },
+    { url = "https://files.pythonhosted.org/packages/94/2b/701a4b0585cb05472a4da28ee28fdfe155f3638f5e1ec92306d924e5faf0/regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b85c2530be953a890eaffde05485238f07029600e8f098cdf1848d414a8b45e4", size = 794976 },
+    { url = "https://files.pythonhosted.org/packages/4b/bf/fa87e563bf5fee75db8915f7352e1887b1249126a1be4813837f5dbec965/regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bb26437975da7dc36b7efad18aa9dd4ea569d2357ae6b783bf1118dabd9ea577", size = 833077 },
+    { url = "https://files.pythonhosted.org/packages/a1/56/7295e6bad94b047f4d0834e4779491b81216583c00c288252ef625c01d23/regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abfa5080c374a76a251ba60683242bc17eeb2c9818d0d30117b4486be10c59d3", size = 823160 },
+    { url = "https://files.pythonhosted.org/packages/fb/13/e3b075031a738c9598c51cfbc4c7879e26729c53aa9cca59211c44235314/regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b7fa6606c2881c1db9479b0eaa11ed5dfa11c8d60a474ff0e095099f39d98e", size = 796896 },
+    { url = "https://files.pythonhosted.org/packages/24/56/0b3f1b66d592be6efec23a795b37732682520b47c53da5a32c33ed7d84e3/regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c32f75920cf99fe6b6c539c399a4a128452eaf1af27f39bce8909c9a3fd8cbe", size = 783997 },
+    { url = "https://files.pythonhosted.org/packages/f9/a1/eb378dada8b91c0e4c5f08ffb56f25fcae47bf52ad18f9b2f33b83e6d498/regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:982e6d21414e78e1f51cf595d7f321dcd14de1f2881c5dc6a6e23bbbbd68435e", size = 781725 },
+    { url = "https://files.pythonhosted.org/packages/83/f2/033e7dec0cfd6dda93390089864732a3409246ffe8b042e9554afa9bff4e/regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a7c2155f790e2fb448faed6dd241386719802296ec588a8b9051c1f5c481bc29", size = 789481 },
+    { url = "https://files.pythonhosted.org/packages/83/23/15d4552ea28990a74e7696780c438aadd73a20318c47e527b47a4a5a596d/regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:149f5008d286636e48cd0b1dd65018548944e495b0265b45e1bffecce1ef7f39", size = 852896 },
+    { url = "https://files.pythonhosted.org/packages/e3/39/ed4416bc90deedbfdada2568b2cb0bc1fdb98efe11f5378d9892b2a88f8f/regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e5364a4502efca094731680e80009632ad6624084aff9a23ce8c8c6820de3e51", size = 860138 },
+    { url = "https://files.pythonhosted.org/packages/93/2d/dd56bb76bd8e95bbce684326302f287455b56242a4f9c61f1bc76e28360e/regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0a86e7eeca091c09e021db8eb72d54751e527fa47b8d5787caf96d9831bd02ad", size = 787692 },
+    { url = "https://files.pythonhosted.org/packages/0b/55/31877a249ab7a5156758246b9c59539abbeba22461b7d8adc9e8475ff73e/regex-2024.11.6-cp312-cp312-win32.whl", hash = "sha256:32f9a4c643baad4efa81d549c2aadefaeba12249b2adc5af541759237eee1c54", size = 262135 },
+    { url = "https://files.pythonhosted.org/packages/38/ec/ad2d7de49a600cdb8dd78434a1aeffe28b9d6fc42eb36afab4a27ad23384/regex-2024.11.6-cp312-cp312-win_amd64.whl", hash = "sha256:a93c194e2df18f7d264092dc8539b8ffb86b45b899ab976aa15d48214138e81b", size = 273567 },
+    { url = "https://files.pythonhosted.org/packages/90/73/bcb0e36614601016552fa9344544a3a2ae1809dc1401b100eab02e772e1f/regex-2024.11.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a6ba92c0bcdf96cbf43a12c717eae4bc98325ca3730f6b130ffa2e3c3c723d84", size = 483525 },
+    { url = "https://files.pythonhosted.org/packages/0f/3f/f1a082a46b31e25291d830b369b6b0c5576a6f7fb89d3053a354c24b8a83/regex-2024.11.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:525eab0b789891ac3be914d36893bdf972d483fe66551f79d3e27146191a37d4", size = 288324 },
+    { url = "https://files.pythonhosted.org/packages/09/c9/4e68181a4a652fb3ef5099e077faf4fd2a694ea6e0f806a7737aff9e758a/regex-2024.11.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:086a27a0b4ca227941700e0b31425e7a28ef1ae8e5e05a33826e17e47fbfdba0", size = 284617 },
+    { url = "https://files.pythonhosted.org/packages/fc/fd/37868b75eaf63843165f1d2122ca6cb94bfc0271e4428cf58c0616786dce/regex-2024.11.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bde01f35767c4a7899b7eb6e823b125a64de314a8ee9791367c9a34d56af18d0", size = 795023 },
+    { url = "https://files.pythonhosted.org/packages/c4/7c/d4cd9c528502a3dedb5c13c146e7a7a539a3853dc20209c8e75d9ba9d1b2/regex-2024.11.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b583904576650166b3d920d2bcce13971f6f9e9a396c673187f49811b2769dc7", size = 833072 },
+    { url = "https://files.pythonhosted.org/packages/4f/db/46f563a08f969159c5a0f0e722260568425363bea43bb7ae370becb66a67/regex-2024.11.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c4de13f06a0d54fa0d5ab1b7138bfa0d883220965a29616e3ea61b35d5f5fc7", size = 823130 },
+    { url = "https://files.pythonhosted.org/packages/db/60/1eeca2074f5b87df394fccaa432ae3fc06c9c9bfa97c5051aed70e6e00c2/regex-2024.11.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3cde6e9f2580eb1665965ce9bf17ff4952f34f5b126beb509fee8f4e994f143c", size = 796857 },
+    { url = "https://files.pythonhosted.org/packages/10/db/ac718a08fcee981554d2f7bb8402f1faa7e868c1345c16ab1ebec54b0d7b/regex-2024.11.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0d7f453dca13f40a02b79636a339c5b62b670141e63efd511d3f8f73fba162b3", size = 784006 },
+    { url = "https://files.pythonhosted.org/packages/c2/41/7da3fe70216cea93144bf12da2b87367590bcf07db97604edeea55dac9ad/regex-2024.11.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:59dfe1ed21aea057a65c6b586afd2a945de04fc7db3de0a6e3ed5397ad491b07", size = 781650 },
+    { url = "https://files.pythonhosted.org/packages/a7/d5/880921ee4eec393a4752e6ab9f0fe28009435417c3102fc413f3fe81c4e5/regex-2024.11.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b97c1e0bd37c5cd7902e65f410779d39eeda155800b65fc4d04cc432efa9bc6e", size = 789545 },
+    { url = "https://files.pythonhosted.org/packages/dc/96/53770115e507081122beca8899ab7f5ae28ae790bfcc82b5e38976df6a77/regex-2024.11.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f9d1e379028e0fc2ae3654bac3cbbef81bf3fd571272a42d56c24007979bafb6", size = 853045 },
+    { url = "https://files.pythonhosted.org/packages/31/d3/1372add5251cc2d44b451bd94f43b2ec78e15a6e82bff6a290ef9fd8f00a/regex-2024.11.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:13291b39131e2d002a7940fb176e120bec5145f3aeb7621be6534e46251912c4", size = 860182 },
+    { url = "https://files.pythonhosted.org/packages/ed/e3/c446a64984ea9f69982ba1a69d4658d5014bc7a0ea468a07e1a1265db6e2/regex-2024.11.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f51f88c126370dcec4908576c5a627220da6c09d0bff31cfa89f2523843316d", size = 787733 },
+    { url = "https://files.pythonhosted.org/packages/2b/f1/e40c8373e3480e4f29f2692bd21b3e05f296d3afebc7e5dcf21b9756ca1c/regex-2024.11.6-cp313-cp313-win32.whl", hash = "sha256:63b13cfd72e9601125027202cad74995ab26921d8cd935c25f09c630436348ff", size = 262122 },
+    { url = "https://files.pythonhosted.org/packages/45/94/bc295babb3062a731f52621cdc992d123111282e291abaf23faa413443ea/regex-2024.11.6-cp313-cp313-win_amd64.whl", hash = "sha256:2b3361af3198667e99927da8b84c1b010752fa4b1115ee30beaa332cabc3ef1a", size = 273545 },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1835,6 +1937,43 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.11.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/5b/3ae20f89777115944e89c2d8c2e795dcc5b9e04052f76d5347e35e0da66e/ruff-0.11.4.tar.gz", hash = "sha256:f45bd2fb1a56a5a85fae3b95add03fb185a0b30cf47f5edc92aa0355ca1d7407", size = 3933063 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/db/baee59ac88f57527fcbaad3a7b309994e42329c6bc4d4d2b681a3d7b5426/ruff-0.11.4-py3-none-linux_armv6l.whl", hash = "sha256:d9f4a761ecbde448a2d3e12fb398647c7f0bf526dbc354a643ec505965824ed2", size = 10106493 },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/9a0962cbb347f4ff98b33d699bf1193ff04ca93bed4b4222fd881b502154/ruff-0.11.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8c1747d903447d45ca3d40c794d1a56458c51e5cc1bc77b7b64bd2cf0b1626cc", size = 10876382 },
+    { url = "https://files.pythonhosted.org/packages/3a/8f/62bab0c7d7e1ae3707b69b157701b41c1ccab8f83e8501734d12ea8a839f/ruff-0.11.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:51a6494209cacca79e121e9b244dc30d3414dac8cc5afb93f852173a2ecfc906", size = 10237050 },
+    { url = "https://files.pythonhosted.org/packages/09/96/e296965ae9705af19c265d4d441958ed65c0c58fc4ec340c27cc9d2a1f5b/ruff-0.11.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f171605f65f4fc49c87f41b456e882cd0c89e4ac9d58e149a2b07930e1d466f", size = 10424984 },
+    { url = "https://files.pythonhosted.org/packages/e5/56/644595eb57d855afed6e54b852e2df8cd5ca94c78043b2f29bdfb29882d5/ruff-0.11.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ebf99ea9af918878e6ce42098981fc8c1db3850fef2f1ada69fb1dcdb0f8e79e", size = 9957438 },
+    { url = "https://files.pythonhosted.org/packages/86/83/9d3f3bed0118aef3e871ded9e5687fb8c5776bde233427fd9ce0a45db2d4/ruff-0.11.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edad2eac42279df12e176564a23fc6f4aaeeb09abba840627780b1bb11a9d223", size = 11547282 },
+    { url = "https://files.pythonhosted.org/packages/40/e6/0c6e4f5ae72fac5ccb44d72c0111f294a5c2c8cc5024afcb38e6bda5f4b3/ruff-0.11.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f103a848be9ff379fc19b5d656c1f911d0a0b4e3e0424f9532ececf319a4296e", size = 12182020 },
+    { url = "https://files.pythonhosted.org/packages/b5/92/4aed0e460aeb1df5ea0c2fbe8d04f9725cccdb25d8da09a0d3f5b8764bf8/ruff-0.11.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:193e6fac6eb60cc97b9f728e953c21cc38a20077ed64f912e9d62b97487f3f2d", size = 11679154 },
+    { url = "https://files.pythonhosted.org/packages/1b/d3/7316aa2609f2c592038e2543483eafbc62a0e1a6a6965178e284808c095c/ruff-0.11.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7af4e5f69b7c138be8dcffa5b4a061bf6ba6a3301f632a6bce25d45daff9bc99", size = 13905985 },
+    { url = "https://files.pythonhosted.org/packages/63/80/734d3d17546e47ff99871f44ea7540ad2bbd7a480ed197fe8a1c8a261075/ruff-0.11.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:126b1bf13154aa18ae2d6c3c5efe144ec14b97c60844cfa6eb960c2a05188222", size = 11348343 },
+    { url = "https://files.pythonhosted.org/packages/04/7b/70fc7f09a0161dce9613a4671d198f609e653d6f4ff9eee14d64c4c240fb/ruff-0.11.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8806daaf9dfa881a0ed603f8a0e364e4f11b6ed461b56cae2b1c0cab0645304", size = 10308487 },
+    { url = "https://files.pythonhosted.org/packages/1a/22/1cdd62dabd678d75842bf4944fd889cf794dc9e58c18cc547f9eb28f95ed/ruff-0.11.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5d94bb1cc2fc94a769b0eb975344f1b1f3d294da1da9ddbb5a77665feb3a3019", size = 9929091 },
+    { url = "https://files.pythonhosted.org/packages/9f/20/40e0563506332313148e783bbc1e4276d657962cc370657b2fff20e6e058/ruff-0.11.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:995071203d0fe2183fc7a268766fd7603afb9996785f086b0d76edee8755c896", size = 10924659 },
+    { url = "https://files.pythonhosted.org/packages/b5/41/eef9b7aac8819d9e942f617f9db296f13d2c4576806d604aba8db5a753f1/ruff-0.11.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7a37ca937e307ea18156e775a6ac6e02f34b99e8c23fe63c1996185a4efe0751", size = 11428160 },
+    { url = "https://files.pythonhosted.org/packages/ff/61/c488943414fb2b8754c02f3879de003e26efdd20f38167ded3fb3fc1cda3/ruff-0.11.4-py3-none-win32.whl", hash = "sha256:0e9365a7dff9b93af933dab8aebce53b72d8f815e131796268709890b4a83270", size = 10311496 },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/2a1c8deb5f5dfa3871eb7daa41492c4d2b2824a74d2b38e788617612a66d/ruff-0.11.4-py3-none-win_amd64.whl", hash = "sha256:5a9fa1c69c7815e39fcfb3646bbfd7f528fa8e2d4bebdcf4c2bd0fa037a255fb", size = 11399146 },
+    { url = "https://files.pythonhosted.org/packages/4f/03/3aec4846226d54a37822e4c7ea39489e4abd6f88388fba74e3d4abe77300/ruff-0.11.4-py3-none-win_arm64.whl", hash = "sha256:d435db6b9b93d02934cf61ef332e66af82da6d8c69aefdea5994c89997c7a0fc", size = 10450306 },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.11.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/ec/aa1a215e5c126fe5decbee2e107468f51d9ce190b9763cb649f76bb45938/s3transfer-0.11.4.tar.gz", hash = "sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679", size = 148419 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/62/8d3fc3ec6640161a5649b2cddbbf2b9fa39c92541225b33f117c37c5a2eb/s3transfer-0.11.4-py3-none-any.whl", hash = "sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d", size = 84412 },
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1866,6 +2005,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
 ]
 
 [[package]]
@@ -1944,6 +2092,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248 },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/cf/756fedf6981e82897f2d570dd25fa597eb3f4459068ae0572d7e888cfd6f/tiktoken-0.9.0.tar.gz", hash = "sha256:d02a5ca6a938e0490e1ff957bc48c8b078c88cb83977be1625b1fd8aac792c5d", size = 35991 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/e5/21ff33ecfa2101c1bb0f9b6df750553bd873b7fb532ce2cb276ff40b197f/tiktoken-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e88f121c1c22b726649ce67c089b90ddda8b9662545a8aeb03cfef15967ddd03", size = 1065073 },
+    { url = "https://files.pythonhosted.org/packages/8e/03/a95e7b4863ee9ceec1c55983e4cc9558bcfd8f4f80e19c4f8a99642f697d/tiktoken-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a6600660f2f72369acb13a57fb3e212434ed38b045fd8cc6cdd74947b4b5d210", size = 1008075 },
+    { url = "https://files.pythonhosted.org/packages/40/10/1305bb02a561595088235a513ec73e50b32e74364fef4de519da69bc8010/tiktoken-0.9.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95e811743b5dfa74f4b227927ed86cbc57cad4df859cb3b643be797914e41794", size = 1140754 },
+    { url = "https://files.pythonhosted.org/packages/1b/40/da42522018ca496432ffd02793c3a72a739ac04c3794a4914570c9bb2925/tiktoken-0.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99376e1370d59bcf6935c933cb9ba64adc29033b7e73f5f7569f3aad86552b22", size = 1196678 },
+    { url = "https://files.pythonhosted.org/packages/5c/41/1e59dddaae270ba20187ceb8aa52c75b24ffc09f547233991d5fd822838b/tiktoken-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:badb947c32739fb6ddde173e14885fb3de4d32ab9d8c591cbd013c22b4c31dd2", size = 1259283 },
+    { url = "https://files.pythonhosted.org/packages/5b/64/b16003419a1d7728d0d8c0d56a4c24325e7b10a21a9dd1fc0f7115c02f0a/tiktoken-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:5a62d7a25225bafed786a524c1b9f0910a1128f4232615bf3f8257a73aaa3b16", size = 894897 },
+    { url = "https://files.pythonhosted.org/packages/7a/11/09d936d37f49f4f494ffe660af44acd2d99eb2429d60a57c71318af214e0/tiktoken-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b0e8e05a26eda1249e824156d537015480af7ae222ccb798e5234ae0285dbdb", size = 1064919 },
+    { url = "https://files.pythonhosted.org/packages/80/0e/f38ba35713edb8d4197ae602e80837d574244ced7fb1b6070b31c29816e0/tiktoken-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:27d457f096f87685195eea0165a1807fae87b97b2161fe8c9b1df5bd74ca6f63", size = 1007877 },
+    { url = "https://files.pythonhosted.org/packages/fe/82/9197f77421e2a01373e27a79dd36efdd99e6b4115746ecc553318ecafbf0/tiktoken-0.9.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cf8ded49cddf825390e36dd1ad35cd49589e8161fdcb52aa25f0583e90a3e01", size = 1140095 },
+    { url = "https://files.pythonhosted.org/packages/f2/bb/4513da71cac187383541facd0291c4572b03ec23c561de5811781bbd988f/tiktoken-0.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc156cb314119a8bb9748257a2eaebd5cc0753b6cb491d26694ed42fc7cb3139", size = 1195649 },
+    { url = "https://files.pythonhosted.org/packages/fa/5c/74e4c137530dd8504e97e3a41729b1103a4ac29036cbfd3250b11fd29451/tiktoken-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cd69372e8c9dd761f0ab873112aba55a0e3e506332dd9f7522ca466e817b1b7a", size = 1258465 },
+    { url = "https://files.pythonhosted.org/packages/de/a8/8f499c179ec900783ffe133e9aab10044481679bb9aad78436d239eee716/tiktoken-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5ea0edb6f83dc56d794723286215918c1cde03712cbbafa0348b33448faf5b95", size = 894669 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -94,14 +94,15 @@ dependencies = [
     { name = "langchain" },
     { name = "langchain-aws" },
     { name = "langchain-community" },
+    { name = "langchain-ollama" },
     { name = "langgraph" },
+    { name = "ollama" },
     { name = "python-dotenv" },
     { name = "tiktoken" },
 ]
 
 [package.optional-dependencies]
 dev = [
-    { name = "black" },
     { name = "coverage" },
     { name = "flake8" },
     { name = "hatch" },
@@ -114,7 +115,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.7.0" },
     { name = "chainlit", git = "https://github.com/Aki-community/chainlit.git?subdirectory=backend&rev=main" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.8.0" },
     { name = "duckduckgo-search", specifier = "<=8.0.0" },
@@ -123,7 +123,9 @@ requires-dist = [
     { name = "langchain", specifier = "==0.3.18" },
     { name = "langchain-aws", specifier = ">=0.2.18" },
     { name = "langchain-community", specifier = "==0.3.17" },
+    { name = "langchain-ollama", specifier = ">=0.3.1" },
     { name = "langgraph", specifier = "==0.3.16" },
+    { name = "ollama", specifier = ">=0.4.7" },
     { name = "pip", marker = "extra == 'dev'", specifier = ">=25.0.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
@@ -184,30 +186,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71", size = 29093 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5", size = 32764 },
-]
-
-[[package]]
-name = "black"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/94/49/26a7b0f3f35da4b5a65f081943b7bcd22d7002f5f0fb8098ec1ff21cb6ef/black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666", size = 649449 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/71/3fe4741df7adf015ad8dfa082dd36c94ca86bb21f25608eb247b4afb15b2/black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b", size = 1650988 },
-    { url = "https://files.pythonhosted.org/packages/13/f3/89aac8a83d73937ccd39bbe8fc6ac8860c11cfa0af5b1c96d081facac844/black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc", size = 1453985 },
-    { url = "https://files.pythonhosted.org/packages/6f/22/b99efca33f1f3a1d2552c714b1e1b5ae92efac6c43e790ad539a163d1754/black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f", size = 1783816 },
-    { url = "https://files.pythonhosted.org/packages/18/7e/a27c3ad3822b6f2e0e00d63d58ff6299a99a5b3aee69fa77cd4b0076b261/black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba", size = 1440860 },
-    { url = "https://files.pythonhosted.org/packages/98/87/0edf98916640efa5d0696e1abb0a8357b52e69e82322628f25bf14d263d1/black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f", size = 1650673 },
-    { url = "https://files.pythonhosted.org/packages/52/e5/f7bf17207cf87fa6e9b676576749c6b6ed0d70f179a3d812c997870291c3/black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3", size = 1453190 },
-    { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926 },
-    { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613 },
-    { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646 },
 ]
 
 [[package]]
@@ -946,6 +924,19 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-ollama"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ollama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/39/32f61a775a85a4162fa1661894ab56f722cf69484bb0bd4cd3812c3bd762/langchain_ollama-0.3.1.tar.gz", hash = "sha256:d847d1bd6da280f7b2f667c98dc240d23f19c72315e0f01d7d05e78a60b42276", size = 20813 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/e9/63fe4aaf5e648d3a152638aba28e9ee1c91e3eebfc216f8f8539a0f0b7f7/langchain_ollama-0.3.1-py3-none-any.whl", hash = "sha256:5b3e01b73014bf52d1b26d5bf920914583954ab12166b18b456da9906216904c", size = 20477 },
+]
+
+[[package]]
 name = "langchain-text-splitters"
 version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1270,6 +1261,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/dc/4fc7c0283abe0981e3b89f9b332a134e237dd476b0c018e1e21083310c31/numpy-2.2.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ee4d528022f4c5ff67332469e10efe06a267e32f4067dc76bb7e2cddf3cd25ff", size = 17879998 },
     { url = "https://files.pythonhosted.org/packages/e5/2b/878576190c5cfa29ed896b518cc516aecc7c98a919e20706c12480465f43/numpy-2.2.4-cp313-cp313t-win32.whl", hash = "sha256:05c076d531e9998e7e694c36e8b349969c56eadd2cdcd07242958489d79a7286", size = 6366896 },
     { url = "https://files.pythonhosted.org/packages/3e/05/eb7eec66b95cf697f08c754ef26c3549d03ebd682819f794cb039574a0a6/numpy-2.2.4-cp313-cp313t-win_amd64.whl", hash = "sha256:188dcbca89834cc2e14eb2f106c96d6d46f200fe0200310fc29089657379c58d", size = 12739119 },
+]
+
+[[package]]
+name = "ollama"
+version = "0.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/6d/dc77539c735bbed5d0c873fb029fb86aa9f0163df169b34152914331c369/ollama-0.4.7.tar.gz", hash = "sha256:891dcbe54f55397d82d289c459de0ea897e103b86a3f1fad0fdb1895922a75ff", size = 12843 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/83/c3ffac86906c10184c88c2e916460806b072a2cfe34cdcaf3a0c0e836d39/ollama-0.4.7-py3-none-any.whl", hash = "sha256:85505663cca67a83707be5fb3aeff0ea72e67846cea5985529d8eca4366564a1", size = 13210 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR sets up the LLM module with the following components:

- Base LLM module structure with provider interfaces
- Bedrock provider implementation with support for various Claude models
- Ollama provider implementation
- Basic config module for environment and path handling
- Comprehensive tests for all components
- Added proper pytest.ini configuration